### PR TITLE
Fix missing fetch dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This bot posts a random joke to a specific channel every 5 minutes.
    ```bash
    npm install
    ```
+   This bot uses the `fetch` API built into Node 18+. If you are on an
+   earlier Node version, install `node-fetch`:
+   ```bash
+   npm install node-fetch
+   ```
 2. Copy `.env.example` to `.env` and fill in your Discord token and channel ID:
    ```bash
    cp .env.example .env

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // bot.js – auto-roasts + “@Bot roast @user” with 5-min user cooldown
 const { Client, GatewayIntentBits } = require("discord.js");
-const fetch = (...a) => import("node-fetch").then(({ default: f }) => f(...a));
+const fetch = global.fetch || ((...a) => import("node-fetch").then(({ default: f }) => f(...a)));
 require("dotenv").config();
 
 const TOKEN = process.env.DISCORD_TOKEN;


### PR DESCRIPTION
## Summary
- handle `fetch` via Node built-in and fallback to `node-fetch`
- document installing `node-fetch` when using older Node

## Testing
- `npm test` *(fails: Error: no test specified)*