### PR TITLE
Improve API error logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,28 +34,55 @@ const failMessage =
 
 async function getRoast(name = "friend") {
   const prompt = `Give me one short, savage but playful roast for a Discord user named "${name}".`;
+  const url = `https://api-inference.huggingface.co/models/${MODEL}`;
+  const bodyData = {
+    inputs: prompt,
+    parameters: { max_new_tokens: 32, temperature: 0.9 },
+  };
+  const opts = {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${HF_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(bodyData),
+  };
   try {
-    const r = await fetch(
-      `https://api-inference.huggingface.co/models/${MODEL}`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${HF_TOKEN}`,
-          "Content-Type": "application/json",
+    const r = await fetch(url, opts);
+    const respText = await r.text();
+    if (!r.ok) {
+      console.error("[HF] Request failed", {
+        request: { url, method: "POST", body: bodyData },
+        response: {
+          status: r.status,
+          statusText: r.statusText,
+          body: respText,
         },
-        body: JSON.stringify({
-          inputs: prompt,
-          parameters: { max_new_tokens: 32, temperature: 0.9 },
-        }),
-      }
-    );
-    if (!r.ok) throw new Error(`HF ${r.status} ${r.statusText}`);
-    const j = await r.json();
+      });
+      return failMessage;
+    }
+    let j;
+    try {
+      j = JSON.parse(respText);
+    } catch (e) {
+      console.error("[HF] JSON parse error", {
+        request: { url, method: "POST", body: bodyData },
+        response: respText,
+      });
+      return failMessage;
+    }
     const text = j[0]?.generated_text?.replace(prompt, "").trim();
     if (text) return text;
-    throw new Error("empty response");
+    console.error("[HF] Unexpected response", {
+      request: { url, method: "POST", body: bodyData },
+      response: j,
+    });
+    return failMessage;
   } catch (err) {
-    console.error("[HF] Roast fetch failed:", err.message);
+    console.error("[HF] Roast fetch error", {
+      request: { url, method: "POST", body: bodyData },
+      error: err.message,
+    });
     return failMessage;
   }
 }


### PR DESCRIPTION
## Summary
- add verbose diagnostics for Hugging Face request failures

## Testing
- `npm test` *(fails: Error: no test specified)*