### PR TITLE
Add local fetch test script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 DISCORD_TOKEN=your-bot-token-here
 DISCORD_CHANNEL_ID=channel-id-to-send-jokes
+DISCORD_GUILD_ID=your-guild-id
+HF_TOKEN=your-huggingface-token

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Joke Discord Bot
+# Roast Discord Bot
 
-This bot posts a random joke to a specific channel every 5 minutes.
+This bot roasts users in your server using a Hugging Face language model. It can
+reply when mentioned and will occasionally roast recently active users.
 
 ## Setup
 
@@ -13,14 +14,26 @@ This bot posts a random joke to a specific channel every 5 minutes.
    ```bash
    npm install node-fetch
    ```
-2. Copy `.env.example` to `.env` and fill in your Discord token and channel ID:
+2. Copy `.env.example` to `.env` and fill in the required values:
    ```bash
    cp .env.example .env
    # edit .env
    ```
+   DISCORD_TOKEN, DISCORD_CHANNEL_ID, DISCORD_GUILD_ID and HF_TOKEN must be set.
+
 3. Run the bot:
    ```bash
    npm start
    ```
 
 Ensure the bot has permission to send messages in the specified channel.
+
+### Testing the Hugging Face request
+
+To test your Hugging Face configuration without running Discord, use:
+
+```bash
+npm run hf-test "SomeUser"
+```
+
+This sends a real request to the configured model and prints the generated roast.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-// bot.js – roasts via Hugging Face Llama-3, auto + on-demand, logs fetch errors
+// Roast bot using Hugging Face, auto + on-demand, logs fetch errors
 const { Client, GatewayIntentBits } = require("discord.js");
-// Use built-in fetch on Node 18+, fall back to node-fetch for older versions
-const fetch =
-  global.fetch || ((...a) => import("node-fetch").then(({ default: f }) => f(...a)));
+// Fetch roast replies from Hugging Face
+const getRoast = require("./roast");
 require("dotenv").config();
 
 const {
@@ -28,64 +27,7 @@ const client = new Client({
 });
 
 // ---------- Hugging Face generation -----------------------------------
-const MODEL = "meta-llama/Meta-Llama-3-8B-Instruct";
-const failMessage =
-  "Sorry, but I seem to be having trouble accessing my AI brain. Ask the mods for help (not @ggoollpp, he will annoy you)";
-
-async function getRoast(name = "friend") {
-  const prompt = `Give me one short, savage but playful roast for a Discord user named "${name}".`;
-  const url = `https://api-inference.huggingface.co/models/${MODEL}`;
-  const bodyData = {
-    inputs: prompt,
-    parameters: { max_new_tokens: 32, temperature: 0.9 },
-  };
-  const opts = {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${HF_TOKEN}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(bodyData),
-  };
-  try {
-    const r = await fetch(url, opts);
-    const respText = await r.text();
-    if (!r.ok) {
-      console.error("[HF] Request failed", {
-        request: { url, method: "POST", body: bodyData },
-        response: {
-          status: r.status,
-          statusText: r.statusText,
-          body: respText,
-        },
-      });
-      return failMessage;
-    }
-    let j;
-    try {
-      j = JSON.parse(respText);
-    } catch (e) {
-      console.error("[HF] JSON parse error", {
-        request: { url, method: "POST", body: bodyData },
-        response: respText,
-      });
-      return failMessage;
-    }
-    const text = j[0]?.generated_text?.replace(prompt, "").trim();
-    if (text) return text;
-    console.error("[HF] Unexpected response", {
-      request: { url, method: "POST", body: bodyData },
-      response: j,
-    });
-    return failMessage;
-  } catch (err) {
-    console.error("[HF] Roast fetch error", {
-      request: { url, method: "POST", body: bodyData },
-      error: err.message,
-    });
-    return failMessage;
-  }
-}
+// getRoast is provided by ./roast
 
 // ---------- activity & cooldown --------------------------------------
 const lastSeen = new Map(); // userId → last message time

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "hf-test": "node test-fetch.js"
   },
   "dependencies": {
     "discord.js": "^14.11.0",

--- a/roast.js
+++ b/roast.js
@@ -1,0 +1,65 @@
+const fetch =
+  global.fetch || ((...a) => import('node-fetch').then(({ default: f }) => f(...a)));
+
+const { HF_TOKEN } = process.env;
+
+const MODEL = 'meta-llama/Meta-Llama-Guard-2-8B';
+const failMessage =
+  'Sorry, but I seem to be having trouble accessing my AI brain. Ask the mods for help (not @ggoollpp, he will annoy you)';
+
+async function getRoast(name = 'friend') {
+  const prompt = `Give me one short, savage but playful roast for a Discord user named "${name}".`;
+  const url = `https://api-inference.huggingface.co/models/${MODEL}`;
+  const bodyData = {
+    inputs: prompt,
+    parameters: { max_new_tokens: 32, temperature: 0.9 },
+  };
+  const opts = {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${HF_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(bodyData),
+  };
+  try {
+    const r = await fetch(url, opts);
+    const respText = await r.text();
+    if (!r.ok) {
+      console.error('[HF] Request failed', {
+        request: { url, method: 'POST', body: bodyData },
+        response: {
+          status: r.status,
+          statusText: r.statusText,
+          body: respText,
+        },
+      });
+      return failMessage;
+    }
+    let j;
+    try {
+      j = JSON.parse(respText);
+    } catch (e) {
+      console.error('[HF] JSON parse error', {
+        request: { url, method: 'POST', body: bodyData },
+        response: respText,
+      });
+      return failMessage;
+    }
+    const text = j[0]?.generated_text?.replace(prompt, '').trim();
+    if (text) return text;
+    console.error('[HF] Unexpected response', {
+      request: { url, method: 'POST', body: bodyData },
+      response: j,
+    });
+    return failMessage;
+  } catch (err) {
+    console.error('[HF] Roast fetch error', {
+      request: { url, method: 'POST', body: bodyData },
+      error: err.message,
+    });
+    return failMessage;
+  }
+}
+
+module.exports = getRoast;

--- a/test-fetch.js
+++ b/test-fetch.js
@@ -1,0 +1,13 @@
+require('dotenv').config();
+const getRoast = require('./roast');
+
+const name = process.argv[2] || 'friend';
+
+getRoast(name)
+  .then((r) => {
+    console.log(r);
+  })
+  .catch((err) => {
+    console.error('Error getting roast:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- move roast generation logic into `roast.js`
- update `index.js` to use the new helper
- expand `.env.example` with guild and Hugging Face token placeholders
- add `test-fetch.js` script and npm script `hf-test`
- document setup and new testing script in README

## Testing
- `npm test` *(fails: no test specified)*
- `npm run hf-test` *(fails: Cannot find module 'dotenv' without `npm install`)*