### PR TITLE
Switch roast bot to Q&A

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Roast Discord Bot
+# Question Answering Discord Bot
 
-This bot roasts users in your server using a Hugging Face language model. It can
-reply when mentioned and will occasionally roast recently active users.
+This bot answers questions using a Hugging Face language model. Mention the bot
+with a question and it will reply with an answer.
 
 ## Setup
 
@@ -33,7 +33,7 @@ Ensure the bot has permission to send messages in the specified channel.
 To test your Hugging Face configuration without running Discord, use:
 
 ```bash
-npm run hf-test "SomeUser"
+npm run hf-test "What is the capital of France?"
 ```
 
-This sends a real request to the configured model and prints the generated roast.
+This sends a real request to the configured model and prints the answer.

--- a/answer.js
+++ b/answer.js
@@ -8,8 +8,8 @@ const MODEL = "HuggingFaceH4/zephyr-7b-beta"; // public, no gating
 const failMessage =
   "Sorry, but I seem to be having trouble accessing my AI brain. Ask the mods for help (not @ggoollpp, he will annoy you)";
 
-async function getRoast(name = "friend") {
-  const prompt = `Give me one short, savage but playful roast for a Discord user named "${name}".`;
+async function getAnswer(question = "What's up?") {
+  const prompt = `Answer the following question clearly and concisely.\nQuestion: ${question}\nAnswer:`;
   const url = `https://api-inference.huggingface.co/models/${MODEL}`;
   const bodyData = {
     inputs: prompt,
@@ -55,7 +55,7 @@ async function getRoast(name = "friend") {
     });
     return failMessage;
   } catch (err) {
-    console.error("[HF] Roast fetch error", {
+    console.error("[HF] Answer fetch error", {
       request: { url, method: "POST", body: bodyData },
       error: err.message,
     });
@@ -63,4 +63,4 @@ async function getRoast(name = "friend") {
   }
 }
 
-module.exports = getRoast;
+module.exports = getAnswer;

--- a/test-fetch.js
+++ b/test-fetch.js
@@ -1,13 +1,13 @@
 require('dotenv').config();
-const getRoast = require('./roast');
+const getAnswer = require('./answer');
 
-const name = process.argv[2] || 'friend';
+const question = process.argv.slice(2).join(' ') || "What's up?";
 
-getRoast(name)
+getAnswer(question)
   .then((r) => {
     console.log(r);
   })
   .catch((err) => {
-    console.error('Error getting roast:', err);
+    console.error('Error getting answer:', err);
     process.exit(1);
   });


### PR DESCRIPTION
## Summary
- switch bot from roasting users to answering questions
- rename `roast.js` -> `answer.js`
- update command-line test script
- simplify main bot logic to reply with answers
- revise documentation

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run hf-test "What is the capital of France?"` *(fails: Cannot find module 'dotenv')*