### PR TITLE
Add jest tests for bot

### DIFF
--- a/__tests__/getAnswer.test.js
+++ b/__tests__/getAnswer.test.js
@@ -1,0 +1,23 @@
+const getAnswer = require('../answer');
+
+describe('getAnswer', () => {
+  const oldFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = oldFetch;
+  });
+
+  test('returns generated text from Hugging Face', async () => {
+    const question = 'What is up?';
+    const prompt = `Answer the following question clearly and concisely.\nQuestion: ${question}\nAnswer:`;
+    const mockResponse = {
+      ok: true,
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify([{ generated_text: `${prompt} Great!` }])
+      ),
+    };
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+    const ans = await getAnswer(question);
+    expect(ans).toBe('Great!');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/messageHandler.test.js
+++ b/__tests__/messageHandler.test.js
@@ -1,0 +1,22 @@
+const handleMessage = require('../messageHandler');
+
+jest.mock('../answer', () => jest.fn(() => Promise.resolve('42')));
+const getAnswer = require('../answer');
+
+describe('message handler', () => {
+  test('replies with answer when mentioned', async () => {
+    const client = { user: { id: 'bot' } };
+    const reply = jest.fn().mockResolvedValue();
+    const msg = {
+      author: { bot: false },
+      mentions: { has: jest.fn().mockReturnValue(true) },
+      content: '<@123> life?',
+      reply,
+    };
+
+    await handleMessage(client, msg);
+
+    expect(getAnswer).toHaveBeenCalledWith('life?');
+    expect(reply).toHaveBeenCalledWith('42');
+  });
+});

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const { Client, GatewayIntentBits } = require("discord.js");
 // Fetch answers from Hugging Face
 const getAnswer = require("./answer");
+const handleMessage = require("./messageHandler");
 require("dotenv").config();
 
 const {
@@ -26,14 +27,7 @@ const client = new Client({
 // getAnswer is provided by ./answer
 
 // message handler
-client.on("messageCreate", async (msg) => {
-  if (msg.author.bot) return;
-  if (!msg.mentions.has(client.user)) return;
-  const question = msg.content.replace(/<@!?\d+>/g, "").trim();
-  if (!question) return;
-  const answer = await getAnswer(question);
-  msg.reply(answer).catch(console.error);
-});
+client.on("messageCreate", (msg) => handleMessage(client, msg));
 
 // startup
 client.once("ready", async () => {

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -1,0 +1,12 @@
+const getAnswer = require('./answer');
+
+async function handleMessage(client, msg) {
+  if (msg.author.bot) return;
+  if (!msg.mentions.has(client.user)) return;
+  const question = msg.content.replace(/<@!?\d+>/g, '').trim();
+  if (!question) return;
+  const answer = await getAnswer(question);
+  await msg.reply(answer).catch(console.error);
+}
+
+module.exports = handleMessage;

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
   "type": "commonjs",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node index.js",
     "hf-test": "node test-fetch.js"
   },
   "dependencies": {
     "discord.js": "^14.11.0",
     "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- expose message handler in new `messageHandler.js`
- update `index.js` to use exported handler
- add Jest with a `test` script
- create tests for `getAnswer` and the message handler

## Testing
- `npm test` *(fails: `jest` not found)*