### PR TITLE
Restrict bot to configured channel and guild

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ with a question and it will reply with an answer.
 
 Ensure the bot has permission to send messages in the specified channel.
 
+The bot only responds to messages in the guild and channel IDs provided in
+`.env`.
+
 ### Testing the Hugging Face request
 
 To test your Hugging Face configuration without running Discord, use:

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ const client = new Client({
 // message handler
 client.on("messageCreate", async (msg) => {
   if (msg.author.bot) return;
+  if (!msg.guild || msg.guild.id !== GUILD_ID) return;
+  if (msg.channel.id !== CHANNEL_ID) return;
   if (!msg.mentions.has(client.user)) return;
   const question = msg.content.replace(/<@!?\d+>/g, "").trim();
   if (!question) return;


### PR DESCRIPTION
## Summary
- limit the message handler to the guild and channel IDs set in `.env`
- clarify in the README that the bot only responds in the configured location

## Testing
- `npm test` *(fails: Error: no test specified)*