### PR TITLE
Add mention testing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,20 @@ To test your Hugging Face configuration without running Discord, use:
 ```bash
 npm run hf-test "What is the capital of France?"
 ```
-
 This sends a real request to the configured model and prints the answer.
+
+### Simulating a mention locally
+
+You can test how the bot responds to a mention without running Discord by
+using the `mention` script. Pass the message you want to send after the bot's
+name:
+
+```bash
+npm run mention "Agi will arrive on 1st November 2012"
+```
+
+This prints the same response that would be sent in Discord when the bot is
+mentioned with that text.
 
 ### AGI arrival predictions
 

--- a/mention.js
+++ b/mention.js
@@ -1,0 +1,42 @@
+require('dotenv').config();
+const getAnswer = require('./answer');
+const { addPrediction, getPredictions } = require('./db');
+
+const text = process.argv.slice(2).join(' ').trim();
+if (!text) {
+  console.error('Usage: npm run mention "<message>"');
+  process.exit(1);
+}
+
+const USER_ID = 'local-user';
+
+async function main() {
+  const match = /agi will arrive on (.+)/i.exec(text);
+  if (match) {
+    const when = match[1].trim();
+    addPrediction(USER_ID, when);
+    console.log(`<@${USER_ID}> Prediction saved for ${when}`);
+    return;
+  }
+
+  if (/^list agi predictions$/i.test(text)) {
+    const predictions = getPredictions();
+    if (predictions.length === 0) {
+      console.log('No AGI predictions saved.');
+    } else {
+      const lines = predictions
+        .map((p) => `<@${p.userId}> predicted ${p.date}`)
+        .join('\n');
+      console.log(lines);
+    }
+    return;
+  }
+
+  const answer = await getAnswer(text);
+  console.log(`<@${USER_ID}> ${answer}`);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js",
-    "hf-test": "node test-fetch.js"
+    "hf-test": "node test-fetch.js",
+    "mention": "node mention.js"
   },
   "dependencies": {
     "discord.js": "^14.11.0",


### PR DESCRIPTION
## Summary
- add `mention` npm script and implementation for local mention testing
- document how to use the new script in README

## Testing
- `npm test` *(fails: Error: no test specified)*